### PR TITLE
Fixed a pylint(E1101) error

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def post_to_server(command):
 
     # Hopefully, our server will always be able to handle your requests
     # but you never know...
-    if reply.status_code != requests.codes.ok:
+    if reply.status_code != requests.codes['ok']:
         print('Error! We seem to have trouble talking to the server...\n')
         print('  The server replied with status code %d' % reply.status_code)
 


### PR DESCRIPTION
Seems like pylint complains about a LookUpDict not having a member,
which is probably created at runtime. The examples still run, but it's
confusing for people using pylint. I know the warning can be supressed, but
it's a tiny change so it's easy for you to patch it upstream.

http://pylint-messages.wikidot.com/messages:e1101
